### PR TITLE
Add option to set homeserver type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Name               | Description
 radius.address     | Address of [FreeRADIUS status server](https://wiki.freeradius.org/config/Status), defaults to `127.0.0.1:18121`.
 radius.secret      | FreeRADIUS client secret, defaults to `adminsecret`.
 radius.timeout     | Timeout, in milliseconds, defaults to `5000`.
-radius.homeservers | Addresses of home servers separated by comma, e.g. "172.28.1.2:1812,172.28.1.3:1812"
+radius.homeservers | Addresses of home servers separated by comma, e.g. "172.28.1.2:1812:auth,172.28.1.3:1813:acct", auth/acct is optional and defaults to all
 web.listen-address | Address to listen on for web interface and telemetry, defaults to `:9812`.
 web.telemetry-path | Path under which to expose metrics, defaults to `/metrics`.
 version            | Display version information
@@ -34,7 +34,7 @@ Name               | Description
 RADIUS_ADDRESS     | Address of [FreeRADIUS status server](https://wiki.freeradius.org/config/Status).
 RADIUS_SECRET      | FreeRADIUS client secret.
 RADIUS_TIMEOUT     | Timeout, in milliseconds.
-RADIUS_HOMESERVERS | Addresses of home servers separated by comma, e.g. "172.28.1.2:1812,172.28.1.3:1812"
+RADIUS_HOMESERVERS | Addresses of home servers separated by comma, e.g. "172.28.1.2:1812:auth,172.28.1.3:1813:acct", auth/acct is optional and defaults to all
 
 ### Metrics
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	metricsPath := fs.String("web.telemetry-path", "/metrics", "A path under which to expose metrics.")
 	radiusTimeout := fs.Int("radius.timeout", 5000, "Timeout, in milliseconds [RADIUS_TIMEOUT].")
 	radiusAddr := fs.String("radius.address", "127.0.0.1:18121", "Address of FreeRADIUS status server [RADIUS_ADDRESS].")
-	homeServers := fs.String("radius.homeservers", "", "List of FreeRADIUS home servers to check, e.g. '172.28.1.2:1812,172.28.1.3:1812' [RADIUS_HOMESERVERS].")
+	homeServers := fs.String("radius.homeservers", "", "List of FreeRADIUS home servers to check, e.g. '172.28.1.2:1812:auth,172.28.1.3:1813:acct' [RADIUS_HOMESERVERS].")
 	radiusSecret := fs.String("radius.secret", "adminsecret", "FreeRADIUS client secret [RADIUS_SECRET].")
 
 	err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarNoPrefix(), ff.WithConfigFileFlag("config"), ff.WithConfigFileParser(ff.JSONParser))


### PR DESCRIPTION
Hello!

When getting metrics about home servers, FreeRADIUS will display errors, when requesting wrong stats about home servers. The request will still succeed, but the errors can fill up logs fast when using the exporter. (This is mentioned in the code.)

I've added an optional third parameter to the home servers, which indicates if it is an auth or acct server, and only request the correct information about the servers, thus eliminating the errors.