### PR TITLE
Add: access control for /metrics with IP/CIDR or via HTTP Header 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ radius.timeout     | Timeout, in milliseconds, defaults to `5000`.
 radius.homeservers | Addresses of home servers separated by comma, e.g. "172.28.1.2:1812:auth,172.28.1.3:1813:acct", auth/acct is optional and defaults to all
 web.listen-address | Address to listen on for web interface and telemetry, defaults to `:9812`.
 web.telemetry-path | Path under which to expose metrics, defaults to `/metrics`.
+web.auth-token     | Auth token required in `X-Auth-Token` header to access `web.telemetry-path` (optional).
+web.allowed-ips    | Comma-separated list of IPs or CIDR ranges allowed to access `web.telemetry-path` (optional).
 version            | Display version information
 config             | Config file (optional)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestWithTokenOrIP(t *testing.T) {
+	allowedCIDRs, err := parseAllowedIPs("192.168.1.0/24,10.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error in test setup: %v", err)
+	}
+	validToken := "secret-token"
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	protected := withTokenOrIP(validToken, allowedCIDRs, handler)
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		authToken  string
+		wantCode   int
+	}{
+		{"Valid IP match subnet", "192.168.1.42:1234", "", http.StatusOK},
+		{"Valid IP exact match", "10.0.0.1:9999", "", http.StatusOK},
+		{"Valid token", "8.8.8.8:1111", "secret-token", http.StatusOK},
+		{"Invalid IP and token", "8.8.8.8:1111", "wrong-token", http.StatusForbidden},
+		{"No auth at all", "8.8.8.8:1111", "", http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/metrics", nil)
+			req.RemoteAddr = tc.remoteAddr
+			if tc.authToken != "" {
+				req.Header.Set("X-Auth-Token", tc.authToken)
+			}
+
+			rec := httptest.NewRecorder()
+			protected.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("Expected %d, got %d", tc.wantCode, rec.Code)
+			}
+		})
+	}
+}
+
+func TestParseAllowedIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []*net.IPNet
+		wantErr  bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:  "valid single IP",
+			input: "192.168.1.10",
+			expected: []*net.IPNet{
+				{
+					IP:   net.ParseIP("192.168.1.10"),
+					Mask: net.CIDRMask(32, 32),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "valid CIDR",
+			input: "10.0.0.0/8",
+			expected: func() []*net.IPNet {
+				_, cidr, _ := net.ParseCIDR("10.0.0.0/8")
+				return []*net.IPNet{cidr}
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "valid mix IP and CIDR",
+			input: "192.168.1.1,10.0.0.0/24",
+			expected: func() []*net.IPNet {
+				_, cidr, _ := net.ParseCIDR("10.0.0.0/24")
+				return []*net.IPNet{
+					{
+						IP:   net.ParseIP("192.168.1.1"),
+						Mask: net.CIDRMask(32, 32),
+					},
+					cidr,
+				}
+			}(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid entry",
+			input:   "not-an-ip",
+			wantErr: true,
+		},
+		{
+			name:    "mixed valid and invalid",
+			input:   "192.168.1.1,not-an-ip",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAllowedIPs(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("expected error = %v, got = %v", tt.wantErr, err)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("expected %+v, got %+v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION

Add optional access control to /metrics (or defined) endpoint with any of (if defined) : 

- IP / CIDR list
- HTTP Header X-Auth-Token value

Including some tests.

Close #25